### PR TITLE
Bug/4/numbermask allows non numeric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 - Add optional parameter on NumberMask to allow for numeric input after mask ends. Default to false.
 - Add optional parameter on NumberMask to allow for users to change the pattern-identifier (`#` by default).
 
+## [1.0.1] - 2023-01-19
+
+### Fixed
+
+- Fixed a bug that allows users to insert non-numeric input due to an incorrect RegExp.
+
 ## [1.0.0] - 2023-01-18
 
 ### Added

--- a/lib/src/number_mask.dart
+++ b/lib/src/number_mask.dart
@@ -69,6 +69,6 @@ class NumberMask extends TextInputFormatter {
   }
 
   String sanitize(String text) {
-    return text.replaceAll(RegExp(r'[^\[0-9]]'), '');
+    return text.replaceAll(RegExp(r'[^0-9]+'), '');
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: number_mask
 description: A Flutter package designed to allow developers to more easily mask numeric form fields.
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/vehm/number_mask
 
 environment:


### PR DESCRIPTION
Fixed the RegExp.

Was `[^\[0-9]]`, is now `[^0-9]+`.